### PR TITLE
Refactor systemd manager into dedicated package

### DIFF
--- a/internal/service/manager_systemd.go
+++ b/internal/service/manager_systemd.go
@@ -1,152 +1,64 @@
 package service
 
 import (
-	"bytes"
-	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"ccgateway/internal/service/systemd"
 )
 
-// linuxManager implements the service.Manager interface using systemd user units.
+// linuxManager wraps systemd.Manager to implement the service.Manager interface.
 type linuxManager struct {
-	systemctlBin string
+	mgr *systemd.Manager
 }
 
 // newLinuxManager returns a Linux systemd-backed Manager implementation.
 func newLinuxManager() Manager {
-	return &linuxManager{systemctlBin: systemctlBin()}
+	return &linuxManager{mgr: systemd.NewManager()}
 }
 
 func (m *linuxManager) Install(files ServiceFiles) error {
-	unitDir := systemdUserDir(files.HomeDir)
-	if err := os.MkdirAll(unitDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create systemd user dir: %w", err)
-	}
-
-	proxyUnit := generateProxyUnit(files)
-	if err := writeAtomic(files.ProxyUnitPath, []byte(proxyUnit), 0o644); err != nil {
-		return fmt.Errorf("failed to write proxy unit: %w", err)
-	}
-
-	syncUnit := generateSyncUnit(files)
-	if err := writeAtomic(files.SyncUnitPath, []byte(syncUnit), 0o644); err != nil {
-		_ = os.Remove(files.ProxyUnitPath)
-		return fmt.Errorf("failed to write sync unit: %w", err)
-	}
-
-	if _, _, err := m.run("--user", "daemon-reload"); err != nil {
-		_ = os.Remove(files.ProxyUnitPath)
-		_ = os.Remove(files.SyncUnitPath)
-		return fmt.Errorf("systemctl daemon-reload failed: %w", err)
-	}
-
-	if _, _, err := m.run("--user", "enable", files.SyncLabel); err != nil {
-		_ = os.Remove(files.ProxyUnitPath)
-		_ = os.Remove(files.SyncUnitPath)
-		return fmt.Errorf("failed to enable sync unit: %w", err)
-	}
-	if _, _, err := m.run("--user", "enable", files.ProxyLabel); err != nil {
-		_, _, _ = m.run("--user", "disable", files.SyncLabel)
-		_ = os.Remove(files.ProxyUnitPath)
-		_ = os.Remove(files.SyncUnitPath)
-		return fmt.Errorf("failed to enable proxy unit: %w", err)
-	}
-
-	return nil
+	return m.mgr.InstallUnits(systemd.UnitFiles{
+		ProxyUnitPath: files.ProxyUnitPath,
+		SyncUnitPath:  files.SyncUnitPath,
+		ProxyBinary:   files.ProxyBinary,
+		ProxyConfig:   files.ProxyConfig,
+		ProxyLog:      files.ProxyLog,
+		SyncLog:       files.SyncLog,
+		SyncScript:    files.SyncScript,
+		HomeDir:       files.HomeDir,
+		ProxyLabel:    files.ProxyLabel,
+		SyncLabel:     files.SyncLabel,
+	})
 }
 
 func (m *linuxManager) Remove(proxyLabel, syncLabel, proxyUnitPath, syncUnitPath string) error {
-	_ = m.stop(proxyLabel)
-	_ = m.stop(syncLabel)
-	_, _, _ = m.run("--user", "disable", proxyLabel)
-	_, _, _ = m.run("--user", "disable", syncLabel)
-	if proxyUnitPath != "" {
-		_ = os.Remove(proxyUnitPath)
-	}
-	if syncUnitPath != "" {
-		_ = os.Remove(syncUnitPath)
-	}
-	_, _, _ = m.run("--user", "daemon-reload")
-	return nil
+	return m.mgr.RemoveUnits(proxyLabel, syncLabel, proxyUnitPath, syncUnitPath)
 }
 
 func (m *linuxManager) Start(proxyLabel, syncLabel string) error {
-	if _, _, err := m.run("--user", "start", syncLabel); err != nil {
-		return fmt.Errorf("failed to start sync service: %w", err)
-	}
-	if _, _, err := m.run("--user", "start", proxyLabel); err != nil {
-		return fmt.Errorf("failed to start proxy service: %w", err)
-	}
-	return nil
+	return m.mgr.Start(proxyLabel, syncLabel)
 }
 
 func (m *linuxManager) Stop(proxyLabel, syncLabel string) error {
-	if err := m.stop(proxyLabel); err != nil {
-		return err
-	}
-	if err := m.stop(syncLabel); err != nil {
-		return err
-	}
-	return nil
+	return m.mgr.Stop(proxyLabel, syncLabel)
 }
 
 func (m *linuxManager) Status(proxyLabel, syncLabel string) (ServiceStatus, error) {
-	proxyLoaded, err := m.isLoaded(proxyLabel)
-	if err != nil {
-		return ServiceStatus{}, err
-	}
-	syncLoaded, err := m.isLoaded(syncLabel)
+	st, err := m.mgr.Status(proxyLabel, syncLabel)
 	if err != nil {
 		return ServiceStatus{}, err
 	}
 	return ServiceStatus{
-		ProxyLoaded: proxyLoaded,
-		SyncLoaded:  syncLoaded,
+		ProxyLoaded: st.ProxyLoaded,
+		SyncLoaded:  st.SyncLoaded,
 	}, nil
-}
-
-func (m *linuxManager) isLoaded(label string) (bool, error) {
-	stdout, _, err := m.run("--user", "show", label, "--property=LoadState", "--value")
-	if err != nil {
-		// If systemctl is not available or unit doesn't exist, treat as not loaded.
-		return false, nil
-	}
-	return strings.TrimSpace(stdout) != "not-found", nil
-}
-
-func (m *linuxManager) stop(label string) error {
-	_, stderr, err := m.run("--user", "stop", label)
-	if err != nil {
-		if strings.Contains(stderr, "not loaded") || strings.Contains(stderr, "not found") {
-			return nil
-		}
-		return fmt.Errorf("failed to stop %s: %w", label, err)
-	}
-	return nil
-}
-
-func (m *linuxManager) run(args ...string) (string, string, error) {
-	bin := m.systemctlBin
-	if bin == "" {
-		bin = systemctlBin()
-	}
-	cmd := exec.Command(bin, args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		return stdout.String(), stderr.String(), fmt.Errorf("systemctl %v failed: %v | stderr=%s", args, err, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.String(), stderr.String(), nil
 }
 
 // linuxUnitPaths resolves Linux systemd user unit file paths for the given labels.
 // Falls back to defaultProxyPath/defaultSyncPath when the corresponding label is empty.
 func linuxUnitPaths(homeDir, defaultProxyPath, defaultSyncPath, proxyLabel, syncLabel string) (string, string) {
-	dir := systemdUserDir(homeDir)
+	dir := systemd.UserDir(homeDir)
 	proxyPath := defaultProxyPath
 	syncPath := defaultSyncPath
 	if p := strings.TrimSpace(proxyLabel); p != "" {
@@ -156,68 +68,4 @@ func linuxUnitPaths(homeDir, defaultProxyPath, defaultSyncPath, proxyLabel, sync
 		syncPath = filepath.Join(dir, s+".service")
 	}
 	return proxyPath, syncPath
-}
-
-func systemdUserDir(homeDir string) string {
-	return filepath.Join(homeDir, ".config", "systemd", "user")
-}
-
-func systemctlBin() string {
-	if v := os.Getenv("CCG_SYSTEMCTL_BIN"); v != "" {
-		return v
-	}
-	return "systemctl"
-}
-
-func generateProxyUnit(files ServiceFiles) string {
-	return fmt.Sprintf(`[Unit]
-Description=ccgateway proxy (%s)
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=%s --config %s
-WorkingDirectory=%s
-Restart=always
-StandardOutput=append:%s
-StandardError=append:%s
-
-[Install]
-WantedBy=default.target
-`, files.ProxyLabel, files.ProxyBinary, files.ProxyConfig, files.HomeDir, files.ProxyLog, files.ProxyLog)
-}
-
-func generateSyncUnit(files ServiceFiles) string {
-	return fmt.Sprintf(`[Unit]
-Description=ccgateway token-sync (%s)
-After=network.target
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash -lc %s
-StandardOutput=append:%s
-StandardError=append:%s
-
-[Install]
-WantedBy=default.target
-`, files.SyncLabel, files.SyncScript, files.SyncLog, files.SyncLog)
-}
-
-func writeAtomic(path string, data []byte, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
-	if err := os.WriteFile(tmp, data, mode); err != nil {
-		return err
-	}
-	if err := os.Chmod(tmp, mode); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return nil
 }

--- a/internal/service/systemd/manager.go
+++ b/internal/service/systemd/manager.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Manager provides low-level systemd user-unit lifecycle operations.
@@ -217,7 +218,7 @@ func writeAtomic(path string, data []byte, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	tmp := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UTC().UnixNano())
 	if err := os.WriteFile(tmp, data, mode); err != nil {
 		return err
 	}

--- a/internal/service/systemd/manager.go
+++ b/internal/service/systemd/manager.go
@@ -1,0 +1,233 @@
+package systemd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Manager provides low-level systemd user-unit lifecycle operations.
+type Manager struct {
+	SystemctlBin string
+}
+
+// ServiceStatus represents the load state of managed systemd units.
+type ServiceStatus struct {
+	ProxyLoaded bool
+	SyncLoaded  bool
+}
+
+// UnitFiles contains all information needed for systemd unit installation.
+type UnitFiles struct {
+	ProxyUnitPath string
+	SyncUnitPath  string
+	ProxyBinary   string
+	ProxyConfig   string
+	ProxyLog      string
+	SyncLog       string
+	SyncScript    string
+	HomeDir       string
+	ProxyLabel    string
+	SyncLabel     string
+}
+
+// NewManager returns a Manager with the default systemctl binary.
+func NewManager() *Manager {
+	return &Manager{SystemctlBin: systemctlBin()}
+}
+
+// InstallUnits writes unit files, reloads the daemon, and enables units.
+func (m *Manager) InstallUnits(files UnitFiles) error {
+	unitDir := UserDir(files.HomeDir)
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create systemd user dir: %w", err)
+	}
+
+	proxyUnit := GenerateProxyUnit(files)
+	if err := writeAtomic(files.ProxyUnitPath, []byte(proxyUnit), 0o644); err != nil {
+		return fmt.Errorf("failed to write proxy unit: %w", err)
+	}
+
+	syncUnit := GenerateSyncUnit(files)
+	if err := writeAtomic(files.SyncUnitPath, []byte(syncUnit), 0o644); err != nil {
+		_ = os.Remove(files.ProxyUnitPath)
+		return fmt.Errorf("failed to write sync unit: %w", err)
+	}
+
+	if _, _, err := m.run("--user", "daemon-reload"); err != nil {
+		_ = os.Remove(files.ProxyUnitPath)
+		_ = os.Remove(files.SyncUnitPath)
+		return fmt.Errorf("systemctl daemon-reload failed: %w", err)
+	}
+
+	if _, _, err := m.run("--user", "enable", files.SyncLabel); err != nil {
+		_ = os.Remove(files.ProxyUnitPath)
+		_ = os.Remove(files.SyncUnitPath)
+		return fmt.Errorf("failed to enable sync unit: %w", err)
+	}
+	if _, _, err := m.run("--user", "enable", files.ProxyLabel); err != nil {
+		_, _, _ = m.run("--user", "disable", files.SyncLabel)
+		_ = os.Remove(files.ProxyUnitPath)
+		_ = os.Remove(files.SyncUnitPath)
+		return fmt.Errorf("failed to enable proxy unit: %w", err)
+	}
+
+	return nil
+}
+
+// RemoveUnits stops, disables, and deletes the given units.
+func (m *Manager) RemoveUnits(proxyLabel, syncLabel, proxyUnitPath, syncUnitPath string) error {
+	_ = m.stop(proxyLabel)
+	_ = m.stop(syncLabel)
+	_, _, _ = m.run("--user", "disable", proxyLabel)
+	_, _, _ = m.run("--user", "disable", syncLabel)
+	if proxyUnitPath != "" {
+		_ = os.Remove(proxyUnitPath)
+	}
+	if syncUnitPath != "" {
+		_ = os.Remove(syncUnitPath)
+	}
+	_, _, _ = m.run("--user", "daemon-reload")
+	return nil
+}
+
+// Start starts the proxy and sync services.
+func (m *Manager) Start(proxyLabel, syncLabel string) error {
+	if _, _, err := m.run("--user", "start", syncLabel); err != nil {
+		return fmt.Errorf("failed to start sync service: %w", err)
+	}
+	if _, _, err := m.run("--user", "start", proxyLabel); err != nil {
+		return fmt.Errorf("failed to start proxy service: %w", err)
+	}
+	return nil
+}
+
+// Stop stops the proxy and sync services.
+func (m *Manager) Stop(proxyLabel, syncLabel string) error {
+	if err := m.stop(proxyLabel); err != nil {
+		return err
+	}
+	if err := m.stop(syncLabel); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Status checks whether the proxy and sync units are loaded.
+func (m *Manager) Status(proxyLabel, syncLabel string) (ServiceStatus, error) {
+	proxyLoaded, err := m.IsLoaded(proxyLabel)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	syncLoaded, err := m.IsLoaded(syncLabel)
+	if err != nil {
+		return ServiceStatus{}, err
+	}
+	return ServiceStatus{ProxyLoaded: proxyLoaded, SyncLoaded: syncLoaded}, nil
+}
+
+// IsLoaded returns true if the given unit is found by systemd.
+func (m *Manager) IsLoaded(label string) (bool, error) {
+	stdout, _, err := m.run("--user", "show", label, "--property=LoadState", "--value")
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(stdout) != "not-found", nil
+}
+
+func (m *Manager) stop(label string) error {
+	_, stderr, err := m.run("--user", "stop", label)
+	if err != nil {
+		if strings.Contains(stderr, "not loaded") || strings.Contains(stderr, "not found") {
+			return nil
+		}
+		return fmt.Errorf("failed to stop %s: %w", label, err)
+	}
+	return nil
+}
+
+func (m *Manager) run(args ...string) (string, string, error) {
+	bin := m.SystemctlBin
+	if bin == "" {
+		bin = systemctlBin()
+	}
+	cmd := exec.Command(bin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("systemctl %v failed: %v | stderr=%s", args, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
+// GenerateProxyUnit returns the systemd unit file content for the proxy service.
+func GenerateProxyUnit(files UnitFiles) string {
+	return fmt.Sprintf(`[Unit]
+Description=ccgateway proxy (%s)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%s --config %s
+WorkingDirectory=%s
+Restart=always
+StandardOutput=append:%s
+StandardError=append:%s
+
+[Install]
+WantedBy=default.target
+`, files.ProxyLabel, files.ProxyBinary, files.ProxyConfig, files.HomeDir, files.ProxyLog, files.ProxyLog)
+}
+
+// GenerateSyncUnit returns the systemd unit file content for the token-sync service.
+func GenerateSyncUnit(files UnitFiles) string {
+	return fmt.Sprintf(`[Unit]
+Description=ccgateway token-sync (%s)
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -lc %s
+StandardOutput=append:%s
+StandardError=append:%s
+
+[Install]
+WantedBy=default.target
+`, files.SyncLabel, files.SyncScript, files.SyncLog, files.SyncLog)
+}
+
+// UserDir returns the systemd user unit directory path.
+func UserDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "systemd", "user")
+}
+
+func systemctlBin() string {
+	if v := os.Getenv("CCG_SYSTEMCTL_BIN"); v != "" {
+		return v
+	}
+	return "systemctl"
+}
+
+func writeAtomic(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmp, data, mode); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/service/systemd/manager_test.go
+++ b/internal/service/systemd/manager_test.go
@@ -1,0 +1,164 @@
+package systemd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateProxyUnitContent(t *testing.T) {
+	files := UnitFiles{
+		ProxyLabel:  "com.test.proxy",
+		ProxyBinary: "/usr/local/bin/cli-proxy-api",
+		ProxyConfig: "/home/user/.ccgateway/config.yaml",
+		HomeDir:     "/home/user",
+		ProxyLog:    "/home/user/.ccgateway/logs/proxy.log",
+	}
+
+	unit := GenerateProxyUnit(files)
+
+	expectations := []string{
+		"[Unit]",
+		"Description=ccgateway proxy (com.test.proxy)",
+		"After=network.target",
+		"[Service]",
+		"Type=simple",
+		fmt.Sprintf("ExecStart=%s --config %s", files.ProxyBinary, files.ProxyConfig),
+		fmt.Sprintf("WorkingDirectory=%s", files.HomeDir),
+		"Restart=always",
+		fmt.Sprintf("StandardOutput=append:%s", files.ProxyLog),
+		fmt.Sprintf("StandardError=append:%s", files.ProxyLog),
+		"[Install]",
+		"WantedBy=default.target",
+	}
+
+	for _, exp := range expectations {
+		if !strings.Contains(unit, exp) {
+			t.Errorf("expected proxy unit to contain %q, got:\n%s", exp, unit)
+		}
+	}
+}
+
+func TestGenerateSyncUnitContent(t *testing.T) {
+	files := UnitFiles{
+		SyncLabel:  "com.test.sync",
+		SyncScript: "/home/user/.ccgateway/sync.sh",
+		SyncLog:    "/home/user/.ccgateway/logs/sync.log",
+	}
+
+	unit := GenerateSyncUnit(files)
+
+	expectations := []string{
+		"[Unit]",
+		"Description=ccgateway token-sync (com.test.sync)",
+		"After=network.target",
+		"[Service]",
+		"Type=oneshot",
+		fmt.Sprintf("ExecStart=/bin/bash -lc %s", files.SyncScript),
+		fmt.Sprintf("StandardOutput=append:%s", files.SyncLog),
+		fmt.Sprintf("StandardError=append:%s", files.SyncLog),
+		"[Install]",
+		"WantedBy=default.target",
+	}
+
+	for _, exp := range expectations {
+		if !strings.Contains(unit, exp) {
+			t.Errorf("expected sync unit to contain %q, got:\n%s", exp, unit)
+		}
+	}
+}
+
+func TestUserDir(t *testing.T) {
+	dir := UserDir("/home/testuser")
+	expected := filepath.Join("/home/testuser", ".config", "systemd", "user")
+	if dir != expected {
+		t.Errorf("expected %q, got %q", expected, dir)
+	}
+}
+
+func TestInstallUnitsCleansUpOnEnableProxyFailure(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "systemctl.log")
+	stubPath := filepath.Join(tmp, "systemctl")
+	proxyUnitPath := filepath.Join(tmp, "systemd", "user", "com.test.proxy.service")
+	syncUnitPath := filepath.Join(tmp, "systemd", "user", "com.test.sync.service")
+
+	// Stub that fails on "enable com.test.proxy" but succeeds otherwise.
+	stubScript := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "` + logPath + `"
+if [[ "$*" == *"enable"*"com.test.proxy"* ]]; then
+  printf 'simulated enable proxy failure\n' >&2
+  exit 1
+fi
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write systemctl stub failed: %v", err)
+	}
+
+	mgr := &Manager{SystemctlBin: stubPath}
+	files := UnitFiles{
+		ProxyUnitPath: proxyUnitPath,
+		SyncUnitPath:  syncUnitPath,
+		ProxyBinary:   filepath.Join(tmp, "proxy", "cli-proxy-api"),
+		ProxyConfig:   filepath.Join(tmp, "proxy", "config.yaml"),
+		ProxyLog:      filepath.Join(tmp, "logs", "proxy.log"),
+		SyncLog:       filepath.Join(tmp, "logs", "sync.log"),
+		SyncScript:    filepath.Join(tmp, "sync.sh"),
+		HomeDir:       tmp,
+		ProxyLabel:    "com.test.proxy",
+		SyncLabel:     "com.test.sync",
+	}
+
+	err := mgr.InstallUnits(files)
+	if err == nil {
+		t.Fatal("expected install failure when enable proxy fails")
+	}
+	if !strings.Contains(err.Error(), "enable proxy") {
+		t.Fatalf("expected enable proxy error context, got: %v", err)
+	}
+
+	// Verify unit files were cleaned up.
+	if _, statErr := os.Stat(proxyUnitPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected proxy unit cleanup, stat error=%v", statErr)
+	}
+	if _, statErr := os.Stat(syncUnitPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected sync unit cleanup, stat error=%v", statErr)
+	}
+
+	logBody, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("read systemctl log failed: %v", readErr)
+	}
+	logText := string(logBody)
+
+	// Should have called disable on the sync label as part of cleanup.
+	if !strings.Contains(logText, "disable") {
+		t.Fatalf("expected cleanup disable call in systemctl log:\n%s", logText)
+	}
+}
+
+func TestStatusWithStubSystemctl(t *testing.T) {
+	tmp := t.TempDir()
+	stubPath := filepath.Join(tmp, "systemctl")
+
+	stubScript := "#!/usr/bin/env bash\nif [[ \"$2\" == \"show\" ]]; then\n  echo \"not-found\"\n  exit 0\nfi\nexit 0\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("failed to write systemctl stub: %v", err)
+	}
+
+	mgr := &Manager{SystemctlBin: stubPath}
+	status, err := mgr.Status("com.test.proxy", "com.test.sync")
+	if err != nil {
+		t.Fatalf("Status() returned error: %v", err)
+	}
+	if status.ProxyLoaded {
+		t.Error("expected ProxyLoaded=false with not-found stub")
+	}
+	if status.SyncLoaded {
+		t.Error("expected SyncLoaded=false with not-found stub")
+	}
+}

--- a/test/integration/systemd_integration_test.go
+++ b/test/integration/systemd_integration_test.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ccgateway/internal/proxy"
+	"ccgateway/internal/service/systemd"
+)
+
+func TestSystemdManagerWithStub(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "systemctl.log")
+	stub := filepath.Join(dir, "systemctl")
+	// Stub script that logs all calls and simulates basic systemctl behaviour.
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+echo "$@" >> "` + logFile + `"
+# Simulate "show --property=LoadState" returning "loaded" after install.
+if [[ "${1:-}" == "--user" && "${2:-}" == "show" ]]; then
+  echo "loaded"
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write stub: %v", err)
+	}
+	t.Setenv("CCG_SYSTEMCTL_BIN", stub)
+
+	mgr := systemd.NewManager()
+	unitDir := filepath.Join(dir, ".config", "systemd", "user")
+	files := systemd.UnitFiles{
+		ProxyUnitPath: filepath.Join(unitDir, "com.test.proxy.service"),
+		SyncUnitPath:  filepath.Join(unitDir, "com.test.sync.service"),
+		ProxyBinary:   "/tmp/cli-proxy-api",
+		ProxyConfig:   filepath.Join(dir, "proxy.yaml"),
+		ProxyLog:      filepath.Join(dir, "proxy.log"),
+		SyncLog:       filepath.Join(dir, "sync.log"),
+		SyncScript:    filepath.Join(dir, "sync.sh"),
+		HomeDir:       dir,
+		ProxyLabel:    "com.test.proxy",
+		SyncLabel:     "com.test.sync",
+	}
+	if err := proxy.WriteSyncScript(files.SyncScript, "/usr/local/bin/ccg", "codex", "default"); err != nil {
+		t.Fatalf("write sync script: %v", err)
+	}
+	if err := proxy.WriteProxyConfig(files.ProxyConfig, 12345, filepath.Join(dir, "auths"), "gpt-5.3-codex"); err != nil {
+		t.Fatalf("write proxy config: %v", err)
+	}
+
+	if err := mgr.InstallUnits(files); err != nil {
+		t.Fatalf("install units failed: %v", err)
+	}
+
+	// Verify unit files were written.
+	if _, err := os.Stat(files.ProxyUnitPath); err != nil {
+		t.Fatalf("proxy unit file missing after install: %v", err)
+	}
+	if _, err := os.Stat(files.SyncUnitPath); err != nil {
+		t.Fatalf("sync unit file missing after install: %v", err)
+	}
+
+	// Verify proxy unit content.
+	proxyContent, err := os.ReadFile(files.ProxyUnitPath)
+	if err != nil {
+		t.Fatalf("read proxy unit: %v", err)
+	}
+	if !strings.Contains(string(proxyContent), "ExecStart=/tmp/cli-proxy-api") {
+		t.Fatalf("proxy unit missing ExecStart, got:\n%s", proxyContent)
+	}
+	if !strings.Contains(string(proxyContent), "Restart=always") {
+		t.Fatalf("proxy unit missing Restart=always, got:\n%s", proxyContent)
+	}
+
+	// Verify sync unit content.
+	syncContent, err := os.ReadFile(files.SyncUnitPath)
+	if err != nil {
+		t.Fatalf("read sync unit: %v", err)
+	}
+	if !strings.Contains(string(syncContent), "Type=oneshot") {
+		t.Fatalf("sync unit missing Type=oneshot, got:\n%s", syncContent)
+	}
+
+	if err := mgr.Start(files.ProxyLabel, files.SyncLabel); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	status, err := mgr.Status(files.ProxyLabel, files.SyncLabel)
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if !status.ProxyLoaded || !status.SyncLoaded {
+		t.Fatalf("expected loaded statuses true: %#v", status)
+	}
+	if err := mgr.Stop(files.ProxyLabel, files.SyncLabel); err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+	if err := mgr.RemoveUnits(files.ProxyLabel, files.SyncLabel, files.ProxyUnitPath, files.SyncUnitPath); err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+
+	b, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log failed: %v", err)
+	}
+	logText := string(b)
+	for _, keyword := range []string{"daemon-reload", "enable", "start", "show", "stop", "disable"} {
+		if !strings.Contains(logText, keyword) {
+			t.Fatalf("expected %q call in systemctl log:\n%s", keyword, logText)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Extract systemd unit lifecycle management into a dedicated `internal/service/systemd` package to improve code organization and testability. The `linuxManager` now delegates to the new `systemd.Manager` type rather than implementing all logic directly.

## Key Changes
- **New package**: Created `internal/service/systemd/manager.go` with:
  - `Manager` type for low-level systemd operations (install, remove, start, stop, status)
  - `UnitFiles` struct to encapsulate unit file configuration
  - `ServiceStatus` struct for status reporting
  - Public functions `GenerateProxyUnit()` and `GenerateSyncUnit()` for unit file generation
  - Public `UserDir()` helper for systemd user directory paths
  - Improved `writeAtomic()` with nanosecond precision for temp file names

- **Refactored `linuxManager`**: Now wraps `systemd.Manager` and delegates all operations, reducing the file from 152 to 64 lines

- **Added comprehensive tests**:
  - Unit tests in `internal/service/systemd/manager_test.go` covering unit generation, cleanup on failure, and status checks
  - Integration test in `test/integration/systemd_integration_test.go` validating the full lifecycle with a stubbed systemctl

## Notable Implementation Details
- Atomic file writes now use nanosecond timestamps to prevent collisions in rapid successive writes
- Error handling preserves cleanup semantics: failed operations attempt to roll back previous changes
- The `systemd` package is self-contained and can be tested independently of the service layer
- Environment variable `CCG_SYSTEMCTL_BIN` support is preserved for testing and custom systemctl paths

https://claude.ai/code/session_01VyazaksLMA7mCmEwzgXXzm